### PR TITLE
Don't try redefine the WSAL constants if they are already defined

### DIFF
--- a/includes/class-constantmanager.php
+++ b/includes/class-constantmanager.php
@@ -58,7 +58,10 @@ class ConstantManager {
 		if ( defined( $name ) && constant( $name ) !== $value ) {
 			throw new Exception( 'Constant already defined with a different value.' );
 		} else {
-			define( $name, $value );
+			// if it's not already defined then define it.
+			if ( ! defined( $name ) ) {
+				define( $name, $value );
+			}
 		}
 		// Add constant to da list.
 		$this->UseConstant( $name, $description );


### PR DESCRIPTION
As an extra safety measure to prevent notices/warnings we won't try redefine WSAL constants if they already are defined with the same values.